### PR TITLE
Reverted db to store control impact as float

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'thor'
 gem 'json'
 gem 'pry'
 
-gem 'inspec_tools', '~> 1.1.5', :git => "https://github.com/mitre/inspec_tools.git"
+gem 'inspec_tools', '~> 1.2.0', :git => "https://github.com/mitre/inspec_tools.git"
 gem 'roo'
 
 group :development, :test do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,12 @@
 module ApplicationHelper
-  def category_button(impact)
-    if impact == 'low'
+  def category_button(impact_string)
+    if impact_string == 'low'
       'btn btn-category-iii'
-    elsif impact == 'medium'
+    elsif impact_string == 'medium'
       'btn btn-category-ii'
-    elsif impact == 'high'
+    elsif impact_string == 'high'
       'btn btn-category-i'
-    elsif impact == 'critical'
+    elsif impact_string == 'critical'
       'btn btn-category-i'
     end
   end

--- a/app/models/control.rb
+++ b/app/models/control.rb
@@ -6,19 +6,26 @@ class Control
   include Mongoid::Userstamps::Model
   field :title, type: String
   field :desc, type: String
-  field :impact, type: String
+  field :impact, type: Float
   field :refs, type: Array, default: []
   field :code, type: String
   field :control_id, type: String
-  field :descriptions, type: Array, default: []
+  field :descriptions, type: Hash, default: []
   embeds_many :tags, cascade_callbacks: true
-  embeds_many :descriptions, cascade_callbacks: true
   field :sl_ref, type: String
   field :sl_line, type: Integer
   belongs_to :profile, inverse_of: :controls
   has_many :results
   validates_presence_of :control_id
   validate :code_is_valid
+
+  IMPACT_SCORES = {
+    'none'     => 0.0,
+    'low'      => 0.01,
+    'medium'   => 0.4,
+    'high'     => 0.7,
+    'critical' => 0.9,
+  }.freeze
 
   def to_jbuilder
     Jbuilder.new do |json|
@@ -74,7 +81,7 @@ class Control
   end
 
   def severity
-    impact.downcase
+    impact_string
   end
 
   def parse_nist_tag(nist_tag)
@@ -130,23 +137,37 @@ class Control
       source_location.try(:each) do |key, value|
         control["sl_#{key}"] = value
       end
+
+      # the type of 'descriptions' for 'inspec json PROFILE' and 'inspec json RESULTS' are different
+      if control['descriptions'].is_a? Array
+        control['descriptions'] = control['descriptions'].map do |desc|
+          [desc['label'], desc['data']]
+        end.to_h
+      end
     end
     controls
   end
 
+  def impact_string
+    IMPACT_SCORES.reverse_each do |name, imp|
+      return name if impact >= imp
+    end
+  end
+
+  def self.is_number?(value)
+    Float(value)
+    true
+  rescue
+    false
+  end
+
   def self.parse_impact(value)
     if value.nil?
-      'none'
-    elsif value.numeric?
-      impact = value.to_f
-      if impact < 0.1 then 'none'
-      elsif impact < 0.4 then 'low'
-      elsif impact < 0.7 then 'medium'
-      elsif impact < 0.9 then 'high'
-      elsif impact >= 0.9 then 'critical'
-      end
+      0.0
+    elsif Control.is_number? value
+      value.to_f
     else
-      value.downcase
+      IMPACT_SCORES[value]
     end
   end
 

--- a/app/models/description.rb
+++ b/app/models/description.rb
@@ -1,5 +1,0 @@
-class Description
-  include Mongoid::Document
-  field :label, type: String
-  field :data, type: String
-end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -101,7 +101,7 @@ class Evaluation
   end
 
   def status_symbol(control, ct_results)
-    if control.impact == 'none'
+    if control.impact_string == 'none'
       :not_applicable
     elsif ct_results.nil?
       :not_tested

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -14,6 +14,7 @@ class Profile
   field :parent_profile, type: String
   field :status, type: String
   field :sha256, type: String
+  field :generator, type: Hash
   embeds_many :depends, cascade_callbacks: true
   embeds_many :supports, cascade_callbacks: true
   has_many :controls, dependent: :destroy

--- a/app/views/controls/_details.html.erb
+++ b/app/views/controls/_details.html.erb
@@ -29,17 +29,17 @@
     <table class="table table-bordered table-striped">
       <tr><td>Control:</td><td><%= control.control_id %></td></tr>
       <tr><td>Title:</td><td><%= control.title %></td></tr>
-      <% if control.descriptions.present? %>
-        <tr><td>Descriptions:</td>
-          <td><ul>
-            <% control.descriptions.each do |desc| %>
-              <li><%= desc.label %>: <%= desc.data %></li>
+      <tr><td>Description:</td>
+        <td>
+          <%= control.desc %>
+          <% unless control.descriptions.nil? %>
+            <% control.descriptions.reject{|k,v| k == 'default'}.each do |name, desc| %>
+              <p/>
+              <b><%= name.upcase %></b>: <%= desc %>
             <% end %>
-          </ul></td>
-        </tr>
-      <% else %>
-        <tr><td>Desc:</td><td><%= control.desc %></td></tr>
-      <% end %>
+          <% end %>
+        </td>
+      </tr>
       <tr><td>Impact:</td><td><%= control.impact %></td></tr>
       <% if nist = control.tag('nist') %>
         <tr><td>NIST Ref:</td><td><%= nist %></td></tr>

--- a/app/views/evaluations/show.html.erb
+++ b/app/views/evaluations/show.html.erb
@@ -974,7 +974,7 @@ function draw_severity_pie_chart(d) {
   ary = [];
   if (d.controls) {
     for(var i=0, len=d.controls.length; i < len; i++) {
-      impact = d.controls[i].impact;
+      impact = d.controls[i].impact_string;
       if (impact == 'low') {
         low += 1;
       } else if (impact == 'medium') {
@@ -1072,7 +1072,7 @@ $("#export-caat").click(function(event) {
     control = controls[i];
     field = [];
 
-    if (impact != 'none' && !vulnList.includes(control.name)) {
+    if (control.impact_string != 'none' && !vulnList.includes(control.name)) {
       vulnList.push(control.name)
       field.push(control.family);              // Control Number
       field.push(br2nl(control.title));        // Finding Title
@@ -1094,7 +1094,7 @@ $("#export-caat").click(function(event) {
       field.push(br2nl(control.fix));          // Recommended Corrective Action(s)
       field.push('');                          // Effect on Business
       field.push('');                          // Likelihood
-      field.push(impact)                       // Impact
+      field.push(control.impact_string)        // Impact
       caat.push(field);
     }
   }

--- a/app/views/profiles/nist.json.jbuilder
+++ b/app/views/profiles/nist.json.jbuilder
@@ -1,17 +1,3 @@
-def convert_impact(impact)
-  if impact == 'none'
-    0.0
-  elsif impact == 'low'
-    0.3
-  elsif impact == 'medium'
-    0.5
-  elsif impact == 'high'
-    0.7
-  elsif impact == 'critical'
-    1.0
-  end
-end
-
 total_impact = 0
 total_children = 0
 json.name @name
@@ -30,13 +16,13 @@ json.children @families do |family|
       json.children @control_hash[control['name']].each do |child|
         json.name child[:name]
         json.severity child[:severity]
-        json.impact convert_impact(child[:impact])
+        json.impact child[:impact]
         json.value 1
         Rails.logger.debug "child[:impact]: #{child[:impact]}"
         if child[:impact]
           control_total_children += 1
-          control_total_impact += convert_impact(child[:impact])
-          Rails.logger.debug "control_total_impact += #{convert_impact(child[:impact])}: #{control_total_impact}"
+          control_total_impact += child[:impact]
+          Rails.logger.debug "control_total_impact += #{child[:impact]}: #{control_total_impact}"
         end
       end
     end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -63,10 +63,10 @@
             <tbody>
               <% @profile.controls.each do |control| %>
               <tr class="<%= control.severity.try(:capitalize) %>" id="<%= control.id %>">
-                <td><button class="<%= category_button(control.impact) %>" style="width:120px" onclick="show_details('<%= @profile.id %>', '<%= control.id %>');">View Details</button></td>
+                <td><button class="<%= category_button(control.impact_string) %>" style="width:120px" onclick="show_details('<%= @profile.id %>', '<%= control.id %>');">View Details</button></td>
                 <td><%= control.title %></td>
                 <td><%= link_to control.control_id, profile_control_path(@profile.id, control.id) %></td>
-                <td><%= control.impact %></td>
+                <td><%= control.impact_string %></td>
                 <td><%= control.nist_tags.join(', ') %></td>
                 <td class="hidden"><%= control.code %></td>
               </tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,16 +19,3 @@ Profile.each do |profile|
     profile.supports.create(name: 'os-family', value: value)
   end
 end
-
-Control.each do |control|
-  if control.impact.numeric?
-    impact = control.impact.to_f
-    if impact < 0.1 then control.impact = 'none'
-    elsif impact < 0.4 then control.impact = 'low'
-    elsif impact < 0.7 then control.impact = 'medium'
-    elsif impact < 0.9 then control.impact = 'high'
-    elsif impact >= 0.9 then control.impact = 'critical'
-    end
-    control.save
-  end
-end

--- a/spec/models/control_spec.rb
+++ b/spec/models/control_spec.rb
@@ -42,18 +42,18 @@ RSpec.describe Control, type: :model do
     end
 
     it 'get low severity' do
-      control.impact = 'low'
+      control.impact = 0.2
       expect(control.severity).to eq 'low'
     end
 
     it 'get medium severity' do
-      control.impact = 'medium'
+      control.impact = 0.5
       expect(control.severity).to eq 'medium'
     end
 
     it 'get high severity' do
-      control.impact = 'high'
-      expect(control.severity).to eq 'high'
+      control.impact = 0.9
+      expect(control.severity).to eq 'critical'
     end
 
     it 'get build json string' do


### PR DESCRIPTION
Reverted db to store control impact as float.
Fixed bug due to inconsistent descriptions json from the inspec tool (inspec/inspec#3682).