### PR TITLE
Added fixes Dockerfile and Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'thor'
 gem 'json'
 gem 'pry'
 
-gem 'inspec_tools', '~> 1.1.5', :git => "https://github.com/mitre/inspec_tools.git"
+gem 'inspec_tools', '~> 1.2', :git => "https://github.com/mitre/inspec_tools.git"
 gem 'roo'
 
 group :development, :test do

--- a/dockerfiles/heimdall/Dockerfile
+++ b/dockerfiles/heimdall/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.5
 
 # sed is build only should be removed at TODO-remove-at-release
 RUN apk --no-cache update && apk --no-cache  --update add ruby ruby-irb ruby-json ruby-rake \
-    ruby-bigdecimal ruby-io-console libstdc++ tzdata nodejs sed libressl \
+    ruby-bigdecimal ruby-io-console libstdc++ tzdata nodejs sed libressl ruby-rdoc ruby-bundler\
 	 libxml2 'imagemagick<7.0.0.0'
 
 ENV RAILS_ROOT /var/www/heimdall
@@ -28,7 +28,6 @@ RUN echo "gem: --no-rdoc --no-ri" >> ~/.gemrc
 # --deployment once Gemfile.lock has been committed
 RUN apk --no-cache --update add --virtual build-dependencies build-base ruby-dev  \
     postgresql-dev libc-dev linux-headers git libxml2-dev 'imagemagick-dev<7.0.0.0' pkgconf && \
-    gem install bundler --no-rdoc --no-ri && \
     bundle install --retry 5 --no-cache --jobs 20 --without development test && \
     apk del build-dependencies
 


### PR DESCRIPTION
Heimdall Dockerfile

Move `bunder` and `rdoc` gem installs to apk package installs with `ruby-bundler` `ruby-rdoc `

Gemfile

Updated gemfile to accept the current version of Inspec tools `1.2`

Signed-off-by: Rony Xavier <rx294@nyu.edu>