### PR TITLE
Slim docker image and use images instead of builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,15 @@ RUN echo "gem: --no-rdoc --no-ri" >> ~/.gemrc
 RUN apk --no-cache --update add build-base \
     libc-dev libxml2-dev imagemagick6 imagemagick6-dev pkgconf nodejs
 
-RUN bundle install --deployment --retry 3 --no-cache --jobs 4 --without development test
+RUN bundle install --without development test -j4 --retry 3
 
 COPY . .
 
-RUN rm -rf tmp/cache spec
-
 # precompile is only necessary for production builds
 RUN sh -c "RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE=xxx bundle exec rake assets:precompile"
+
+RUN rm -rf tmp/cache spec /usr/local/bundle/cache && find /usr/local/bundle/gems/ -name "*.c" -delete && \
+    find /usr/local/bundle/gems/ -name "*.o"
 
 # The container above is only used for building. Once the source code is built we copy
 # the required artifacts out of the build above and put them in a clean container.
@@ -37,11 +38,10 @@ RUN mkdir -p $RAILS_ROOT
 
 WORKDIR $RAILS_ROOT
 
+COPY --from=Builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=Builder $RAILS_ROOT $RAILS_ROOT
 
 RUN apk --no-cache --update add nodejs imagemagick6
-
-RUN bundle install --deployment --retry 3 --no-cache --jobs 4 --without development test
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,3 @@ services:
 
 volumes:
   mongo_data:
-  heimdall_secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     expose:
       - "27017"
   web:
-    build: .
+    image: rbclark/heimdall:latest
     environment:
       MONGO_TCP_ADDR: db
       MONGO_TCP_PORT: 27017


### PR DESCRIPTION
By not passing the `--deployment` flag to docker we are able to just copy the contents of `/usr/local/bundle/` over and remove the files we don't need. This makes it where we don't have to run `bundle install` in the 2nd container. Also use Dockerhub for building images instead of requiring users to build them locally.