### PR TITLE
Update mongoid.yml config to use URI instead of using separate host and database entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "gem: --no-rdoc --no-ri" >> ~/.gemrc
 RUN apk --no-cache --update add build-base \
     libc-dev libxml2-dev imagemagick6 imagemagick6-dev pkgconf nodejs
 
-RUN bundle install --without development test -j4 --retry 3
+RUN gem install bundler && bundle install --without development test -j4 --retry 3
 
 COPY . .
 
@@ -41,7 +41,7 @@ WORKDIR $RAILS_ROOT
 COPY --from=Builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=Builder $RAILS_ROOT $RAILS_ROOT
 
-RUN apk --no-cache --update add nodejs imagemagick6
+RUN apk --no-cache --update add nodejs imagemagick6 && gem install bundler
 
 EXPOSE 3000
 

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -5,11 +5,7 @@ development:
     default:
       # Defines the name of the default database that Mongoid can connect to.
       # (required).
-      database: dashboard_development
-      # Provides the hosts the default client can connect to. Must be an array
-      # of host:port pairs. (required)
-      hosts:
-        - <%= ENV.fetch('MONGO_TCP_ADDR', '127.0.0.1') %>:<%= ENV.fetch('MONGO_TCP_PORT', '27017') %>
+      uri: <%= ENV.fetch('MONGODB_URI', 'mongodb://127.0.0.1:27017/dashboard_development') %>
       options:
         # Change the default write concern. (default = { w: 1 })
         # write:
@@ -148,9 +144,7 @@ development:
 test:
   clients:
     default:
-      database: dashboard_test
-      hosts:
-        - <%= ENV.fetch('MONGO_TCP_ADDR', '127.0.0.1') %>:<%= ENV.fetch('MONGO_TCP_PORT', '27017') %>
+      uri: <%= ENV.fetch('MONGODB_URI', 'mongodb://127.0.0.1:27017/dashboard_test') %>
       options:
         raise_not_found_error: false
         read:
@@ -166,10 +160,7 @@ production:
       # A session can have any number of hosts. Usually 1 for a single
       # server setup, and at least 3 for a replica set. Hosts must be
       # an array of host:port pairs. This session is single server.
-      hosts:
-        - <%= ENV.fetch('MONGO_TCP_ADDR', '127.0.0.1') %>:<%= ENV.fetch('MONGO_TCP_PORT', '27017') %>
-      # Define the default database name.
-      database: heimdall2_production
+      uri: <%= ENV.fetch('MONGODB_URI', 'mongodb://127.0.0.1:27017/heimdall2_production') %>
       # Since this database points at a session connected to MongoHQ, we must
       # provide the authentication details.
       #username: user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     environment:
       MONGO_TCP_ADDR: db
       MONGO_TCP_PORT: 27017
+      MONGODB_URI: mongodb://db:27017/heimdall2_production
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_ENV: production
     env_file: .env-prod


### PR DESCRIPTION
This allows for easily setting up Heimdall on Heroku since the MONGODB_URI can be fully customized.