### PR TITLE
When using docker-compose cleanup the tmp/pids/server.pid file before starting the server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_ENV: production
     env_file: .env-prod
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
Currently if you run `docker-compose up`, kill the process and then run `docker-compose up` again you will receive an error stating `web_1  | A server is already running. Check /var/www/heimdall/tmp/pids/server.pid.` This removes the pid file that it is complaining about during startup.