### PR TITLE
Fix rails entrypoint to include bundle exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,6 @@ RUN apk --no-cache --update add nodejs imagemagick6 postgresql-dev tzdata && gem
 
 EXPOSE 3000
 
-CMD ["bundle", "exec", "rails", "server", "-p", "3000", "-b", "0.0.0.0"]
+ENTRYPOINT ["bundle", "exec"]
+
+CMD ["rails", "server", "-p", "3000", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Make sure you have run the setup steps at least once before following these step
 
 1. Run the following command in a terminal window:
    - `docker-compose up -d`
-2. Go to `127.0.0.1:3000/heimdall` in a web browser
+2. Go to `127.0.0.1:3000` in a web browser
 
 ##### Updating Docker Container
 
@@ -111,7 +111,7 @@ A new version of the docker container can be retrieved by running:
 ```
 docker-compose pull
 docker-compose up -d
-docker-compose run web bundle exec rake db:migrate
+docker-compose run web rake db:migrate
 ```
 
 This will fetch the latest version of the container, redeploy if a newer version exists, and then apply any database migrations if applicable. No data should be lost by this operation.


### PR DESCRIPTION
Without this if the rake version installed in the container drifts from the one in the Gemfile we will receive an error.