### PR TITLE
Create circles if they do not already exist and are requested via the API

### DIFF
--- a/app/controllers/circles_controller.rb
+++ b/app/controllers/circles_controller.rb
@@ -32,7 +32,6 @@ class CirclesController < ApplicationController
   def create
     @circle = Circle.new(circle_params)
     @circle.created_by = current_user
-    current_user.add_role(:owner, @circle)
     respond_to do |format|
       if @circle.save
         format.html { redirect_to @circle, notice: 'Circle was successfully created.' }

--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -2,8 +2,9 @@ class Circle < ApplicationRecord
   resourcify
   has_and_belongs_to_many :evaluations
   has_and_belongs_to_many :profiles
-  belongs_to :created_by, class_name: 'User', foreign_key: 'created_by_id'
+  belongs_to :created_by, class_name: 'User'
   validates_presence_of :name
+  after_create :assign_owner
 
   def readable_profiles
     retval = profiles
@@ -23,7 +24,7 @@ class Circle < ApplicationRecord
     recents = Hash[recents.sort_by { |key, _| key }]
     ret_hsh = {}
     recents.each do |tl, ary|
-      ret_hsh[tl] = ary.sort
+      ret_hsh[tl] = ary.sort_by(&:created_at)
     end
     ret_hsh
   end
@@ -37,5 +38,11 @@ class Circle < ApplicationRecord
       recents[key] << obj
     end
     recents
+  end
+
+  private
+
+  def assign_owner
+    self.created_by.add_role(:owner, self)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -113,8 +113,8 @@ class Profile < ApplicationRecord
       if ctl.present? and results.present?
         results.each do |result|
           result[:evaluation_id] = evaluation_id
-          ctl.results.create(result)
         end
+        ctl.results.create(results)
       end
     end
   end


### PR DESCRIPTION
From what I have seen so far Circles are mostly useful on a per-machine basis. Creating all of the circles manually is an unnecessary task since they can simply be created on push.

Also Fixes #64 