### PR TITLE
Cleanup docker compose to work with Postgres 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ inspec-tools/
 /.vagrant/
 rails_best_practices_output.html
 
-# Used by dotenv library to load environment variables.
-# .env
+# Used by dotenv library and docker-compose to load environment variables.
+.env
 
 ## Specific to RubyMotion:
 .dat*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     # image: web:1.0
     image: mitre/heimdall:latest
     environment:
-      DATABASE_URL: "postgres://postgres@db/heimdall_postgres_production"
+      DATABASE_URL: postgres://postgres@db/heimdall_postgres_production
       PGPASSWORD: ${POSTGRES_PASSWORD}
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_ENV: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     restart: unless-stopped
     volumes:
       - heimdall_dbdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    env_file: .env-prod
     expose:
       - "5432"
   web:
@@ -14,7 +17,8 @@ services:
     # image: web:1.0
     image: mitre/heimdall:latest
     environment:
-      DATABASE_URL: postgres://postgres@db/heimdall_postgres_production
+      DATABASE_URL: "postgres://postgres@db/heimdall_postgres_production"
+      PGPASSWORD: ${POSTGRES_PASSWORD}
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_ENV: production
       HEIMDALL_RELATIVE_URL_ROOT: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,22 +3,18 @@ version: '3.5'
 services:
   # If you wish to use a db other than mongo, this is 100% wrong
   db:
-    image: postgres:latest
+    image: postgres:12
     restart: unless-stopped
     volumes:
       - heimdall_dbdata:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    env_file: .env-prod
     expose:
       - "5432"
   web:
-    # build: .
-    # image: web:1.0
     image: mitre/heimdall:latest
     environment:
-      DATABASE_URL: postgres://postgres@db/heimdall_postgres_production
-      PGPASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db/heimdall_postgres_production
       RAILS_SERVE_STATIC_FILES: "true"
       RAILS_ENV: production
       HEIMDALL_RELATIVE_URL_ROOT: ""

--- a/setup-docker-secrets.sh
+++ b/setup-docker-secrets.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+if [ -f .env ]; then
+	echo ".env already exists, if you would like to regenerate your secrets, please delete this file and re-run the script."
+else
+	echo ".env does not exist, creating..."
+	(umask 066; touch .env)
+fi
+
+if ! grep -qF "POSTGRES_PASSWORD" .env; then
+	echo ".env does not contain POSTGRES_PASSWORD, generating secret..."
+	echo -e "\nPOSTGRES_PASSWORD=$(openssl rand -base64 33)" >> .env
+fi
+
+
 if [ -f .env-prod ]; then
 	echo ".env-prod already exists, if you would like to regenerate your secrets, please delete this file and re-run the script."
 else
@@ -10,4 +23,5 @@ CIPHER_PASSWORD=$(openssl rand -hex 64)
 CIPHER_SALT=$(openssl rand -hex 32)
 EOF
 fi
+
 echo "Done"


### PR DESCRIPTION
Remove separate database password environment variable for the web application.
Do not pass rails .env-prod file to the postgres container since it doesn't need access to those secrets to operate.
Lock the postgres container to postgres 12 to avoid this type of problem in the future.

Superseeds #121 