### PR TITLE
removes dev tables from schema

### DIFF
--- a/db/migrate/20200827174100_remove_dev_tables.rb
+++ b/db/migrate/20200827174100_remove_dev_tables.rb
@@ -1,0 +1,11 @@
+class RemoveDevTables < ActiveRecord::Migration[5.2]
+  def change
+    table_exists?(:api_keys) ? drop_table(:api_keys) : nil
+    table_exists?(:auths_user_pass) ? drop_table(:auths_user_pass) : nil
+    table_exists?(:reset_tokens) ? drop_table(:reset_tokens) : nil
+    table_exists?(:sessions) ? drop_table(:sessions) : nil
+    table_exists?(:usergroups) ? drop_table(:usergroups) : nil
+    table_exists?(:usergroups_roles) ? drop_table(:usergroups_roles) : nil
+    table_exists?(:users_usergroups) ? drop_table(:users_usergroups) : nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_20_183613) do
+ActiveRecord::Schema.define(version: 2020_08_27_174100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "api_keys", id: :serial, force: :cascade do |t|
-    t.datetime "expiration"
-    t.string "key", limit: 255
-    t.string "name", limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "role_id"
-    t.integer "user_id"
-  end
 
   create_table "aspects", force: :cascade do |t|
     t.string "name"
@@ -32,16 +22,6 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["profile_id"], name: "index_aspects_on_profile_id"
-  end
-
-  create_table "auths_user_pass", id: :serial, force: :cascade do |t|
-    t.string "username", limit: 255
-    t.string "encrypted_password", limit: 255
-    t.boolean "disabled"
-    t.datetime "expiration"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "user_id"
   end
 
   create_table "circles", force: :cascade do |t|
@@ -106,6 +86,9 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "evaluation_id"
+    t.string "skip_message"
+    t.string "compliance"
+    t.string "supermarket"
     t.index ["evaluation_id"], name: "index_depends_on_evaluation_id"
     t.index ["profile_id"], name: "index_depends_on_profile_id"
   end
@@ -233,14 +216,6 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.index ["control_id"], name: "index_refs_on_control_id"
   end
 
-  create_table "reset_tokens", id: :serial, force: :cascade do |t|
-    t.datetime "expiration"
-    t.string "token", limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "auth_user_pass_id"
-  end
-
   create_table "results", force: :cascade do |t|
     t.string "status"
     t.text "code_desc"
@@ -268,14 +243,6 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.datetime "updated_at", null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource_type_and_resource_id"
-  end
-
-  create_table "sessions", id: :serial, force: :cascade do |t|
-    t.datetime "expiration"
-    t.string "key", limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer "user_id"
   end
 
   create_table "source_locations", force: :cascade do |t|
@@ -321,18 +288,6 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.index ["tagger_type", "tagger_id"], name: "index_tags_on_tagger_type_and_tagger_id"
   end
 
-  create_table "usergroups", id: :serial, force: :cascade do |t|
-    t.string "name", limit: 255
-    t.boolean "personal"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "usergroups_roles", primary_key: ["usergroup_id", "role_id"], force: :cascade do |t|
-    t.integer "usergroup_id", null: false
-    t.integer "role_id", null: false
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "type"
     t.string "first_name"
@@ -363,11 +318,6 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.index ["role_id"], name: "index_users_roles_on_role_id"
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
     t.index ["user_id"], name: "index_users_roles_on_user_id"
-  end
-
-  create_table "users_usergroups", primary_key: ["user_id", "usergroup_id"], force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "usergroup_id", null: false
   end
 
   create_table "waiver_data", force: :cascade do |t|
@@ -407,10 +357,7 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "api_keys", "roles", name: "api_keys_role_id_fkey", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "api_keys", "users", name: "api_keys_user_id_fkey", on_update: :cascade, on_delete: :nullify
   add_foreign_key "aspects", "profiles"
-  add_foreign_key "auths_user_pass", "users", name: "auths_user_pass_user_id_fkey", on_update: :cascade, on_delete: :nullify
   add_foreign_key "controls", "profiles"
   add_foreign_key "depends", "evaluations"
   add_foreign_key "depends", "profiles"
@@ -422,17 +369,11 @@ ActiveRecord::Schema.define(version: 2020_02_20_183613) do
   add_foreign_key "inputs", "profiles"
   add_foreign_key "platforms", "evaluations"
   add_foreign_key "refs", "controls"
-  add_foreign_key "reset_tokens", "auths_user_pass", column: "auth_user_pass_id", name: "reset_tokens_auth_user_pass_id_fkey", on_update: :cascade, on_delete: :nullify
   add_foreign_key "results", "controls"
   add_foreign_key "results", "evaluations"
-  add_foreign_key "sessions", "users", name: "sessions_user_id_fkey", on_update: :cascade, on_delete: :nullify
   add_foreign_key "source_locations", "controls"
   add_foreign_key "statistics", "evaluations"
   add_foreign_key "supports", "profiles"
-  add_foreign_key "usergroups_roles", "roles", name: "usergroups_roles_role_id_fkey", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "usergroups_roles", "usergroups", name: "usergroups_roles_usergroup_id_fkey", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "users_usergroups", "usergroups", name: "users_usergroups_usergroup_id_fkey", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "users_usergroups", "users", name: "users_usergroups_user_id_fkey", on_update: :cascade, on_delete: :cascade
   add_foreign_key "waiver_data", "controls"
   add_foreign_key "waiver_data", "evaluations"
 end


### PR DESCRIPTION
This removes some dev tables that ended up in the database schema and makes the schema match the migrations.

Signed-off-by: Robert Thew <rthew@mitre.org>