### PR TITLE
Health check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,9 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 
+# basic health check gem
+gem 'health_check'
+
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,8 @@ GEM
     hashdiff (1.0.0)
     hashery (2.1.2)
     hashie (3.6.0)
+    health_check (3.0.0)
+      railties (>= 5.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -778,6 +780,7 @@ DEPENDENCIES
   fuzzy-string-match
   gibberish
   github_changelog_generator
+  health_check
   inspec_tools (>= 1.4.2)
   jbuilder (~> 2.5)
   json


### PR DESCRIPTION
When in the course of human events becomes necessary for one peoples to dissolve the timeout bandwidth that connected them with dysfunctional load balancers and to assume the among the powers of Docker the separate and equal station to which the laws of Computer Science and Computer Engineering entitle them, a decent respect to the opinions of high availability requires that they should declare causes which impel them to health checks. We hold these truths that all instances are created equal and that they are endowed by MITRE with resilient capabilities, that among these are high availability, scalability and cost effectiveness.

**TLDR** This PR adds the health_check gem and defaults to that gem's default settings. /health_check returns success 200 after Heimdall is running and the AWS ALB uses this path to validate Heimdall is healthy. The terraform deployment creates a load balancer that needs a health check endpoint that it can monitor to deregisters fargate tasks when an instance doesn't return healthy. @amehta-mitre 